### PR TITLE
Replace custom action with AVH CLI

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -14,65 +14,59 @@ name: Arm Virtual Hardware basic example - github hosted - remote AWS via GH plu
 on:
   push:
     branches: [ main ]
-    paths:
-      - .github/workflows/basic.yml
-      - basic/**/*
   pull_request:
-    branches: [ main ]
     paths:
       - .github/workflows/basic.yml
       - basic/**/*
-
-# To allow you to run this workflow manually from the GitHub Actions tab add
   workflow_dispatch:
 
 env:
-  # VHT-AMI expects those environments be presented.
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+  AWS_S3_BUCKET_NAME: ${{ secrets.AWS_S3_BUCKET_NAME }}
+  AWS_IAM_PROFILE: ${{ secrets.AWS_IAM_PROFILE }}
+  AWS_SECURITY_GROUP_ID: ${{ secrets.AWS_SECURITY_GROUP_ID }}
+  AWS_SUBNET_ID: ${{ secrets.AWS_SUBNET_ID }}
 jobs:
   ci_test:
     runs-on: ubuntu-latest
     outputs:
-      vhtresult: ${{ steps.vht.conclusion }}
-      testbadge: ${{ steps.result.outputs.badge }}
+      vhtresult: ${{ steps.avh.conclusion }}
+      testbadge: ${{ steps.avh.outputs.badge }}
     steps:
     - name: Check out repository code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
-    - name: Install Python packages
-      run: pip install -r basic/requirements.txt
-
-    - uses: ARM-Software/VHT-AMI@v2.1
-      id: vht
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v2
       with:
-        ec2_instance_type: t2.micro
-        ec2_security_group_id: ${{ secrets.AWS_SECURITY_GROUP_ID }}
-        iam_profile: ${{ secrets.AWS_IAM_PROFILE }}
-        s3_bucket_name: ${{ secrets.AWS_S3_BUCKET_NAME }}
-        ssh_key_name: common
-        subnet_id: ${{ secrets.AWS_SUBNET_ID }}
-        terminate_ec2_instance: 'true'
-        vht_ami_version: '1.1.0'
-        vht_in: ./basic/
+        python-version: '3.10'
 
-    - name: Fetch results from VHT
-      id: result
+    - name: Checkout Python AVH Client
+      uses: actions/checkout@v3
+      with:
+        repository: JonatanAntoni/VHT
+        ref: refactoring
+        path: AVH
+
+    - name: Install Python AVH Client
       run: |
-          tar xvzf out.tar
-          cp ./home/ubuntu/vhtwork/out/basic.axf basic/
-          cp ./home/ubuntu/vhtwork/out/basic.axf.stdio basic/vht-$(date +'%Y%m%d%H%M%S').log
-          cd basic
-          ./build.py --verbose -t debug report
+        pip install -e AVH/infrastructure/python_resources
+
+    - uses: ammaraskar/gcc-problem-matcher@master
+
+    - name: Run tests
+      id: avh
+      run: |
+        arm-vhclient -b aws execute --specfile basic/avh.yml
 
     - name: Archive results
       uses: actions/upload-artifact@v2
       with:
         name: results
         path: |
-          basic/basic.axf
-          basic/vht-*.log
+          basic/basic-*.zip
           basic/basic-*.xunit
         retention-days: 1
         if-no-files-found: error
@@ -83,6 +77,8 @@ jobs:
       with:
         check_name: "Test results"
         report_paths: basic/basic-*.xunit
+      if: always()
+
 
   badge:
     if: always() && github.event_name == 'push'

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -43,23 +43,16 @@ jobs:
       with:
         python-version: '3.10'
 
-    - name: Checkout Python AVH Client
-      uses: actions/checkout@v3
-      with:
-        repository: JonatanAntoni/VHT
-        ref: refactoring
-        path: AVH
-
-    - name: Install Python AVH Client
+    - name: Install AVH Client for Python
       run: |
-        pip install -e AVH/infrastructure/python_resources
+        pip install git+https://github.com/ARM-software/avhclient.git@v0.1.1
 
     - uses: ammaraskar/gcc-problem-matcher@master
 
     - name: Run tests
       id: avh
       run: |
-        arm-vhclient -b aws execute --specfile basic/avh.yml
+        avhclient -b aws execute --specfile basic/avh.yml
 
     - name: Archive results
       uses: actions/upload-artifact@v2

--- a/basic/avh.yml
+++ b/basic/avh.yml
@@ -2,7 +2,7 @@ name: "VHT GetStarted Example"
 workdir: ./
 backend:
   aws:
-    ami-version: 1.1.0
+    ami-version: ~=1.1
     instance-type: t2.micro
 upload:
   - RTE/**/*

--- a/basic/avh.yml
+++ b/basic/avh.yml
@@ -1,5 +1,9 @@
 name: "VHT GetStarted Example"
 workdir: ./
+backend:
+  aws:
+    ami-version: 1.1.0
+    instance-type: t2.micro
 upload:
   - RTE/**/*
   - -:RTE/**/RTE_Components.h
@@ -13,10 +17,10 @@ upload:
 steps:
   - run: |
       pip install -r requirements.txt
-      python build.py --verbose cbuild vht
+      python build.py --verbose build run
 download:
   - RTE/**/RTE_Components.h
   - Objects/basic.axf
   - Objects/basic.axf.map
   - basic-*.xunit
-  - vht-*.log
+  - basic-*.zip

--- a/basic/basic.debug.cprj
+++ b/basic/basic.debug.cprj
@@ -10,7 +10,7 @@
 
   <packages>
     <package name="CMSIS" vendor="ARM"/>
-    <package name="V2M_MPS3_SSE_300_BSP" vendor="ARM"/>
+    <package name="V2M_MPS3_SSE_300_BSP" vendor="ARM" version="1.2.0:1.2.0"/>
     <package name="Unity" vendor="Arm-Packs"/>
     <package name="ARM_Compiler" vendor="Keil"/>
   </packages>

--- a/basic/build.py
+++ b/basic/build.py
@@ -11,8 +11,7 @@ from io import StringIO
 from junit_xml import TestSuite, TestCase, to_xml_report_string
 from os import environ
 from pathlib import Path
-from tempfile import NamedTemporaryFile
-from typing import AnyStr, Tuple
+from typing import Tuple
 
 from matrix_runner import main, matrix_axis, matrix_action, matrix_command, ConsoleReport, CropReport, ReportFilter
 
@@ -22,6 +21,7 @@ UNITTEST_BADGE_COLOR = {
     False: 'yellow',    # unstable: not all tests passing
     None: 'red'         # error: no test results generated
 }
+
 
 class UnityReport(ReportFilter):
     class Result(ReportFilter.Result, ReportFilter.Summary):
@@ -80,6 +80,7 @@ class UnityReport(ReportFilter):
         super(UnityReport, self).__init__()
         self.args = args
 
+
 @matrix_axis("target", "t", "The project target(s) to build")
 class TargetAxis(Enum):
     debug = ('debug')
@@ -90,6 +91,7 @@ def cbuild(config):
     """Build the config(s) with CMSIS-Build"""
     yield run_cbuild(config)
 
+
 @matrix_action
 def vht(config, results):
     """Run the config(s) with fast model"""
@@ -99,6 +101,7 @@ def vht(config, results):
     with open(f"vht-{ts}.log", "w") as file:
         results[0].output.seek(0)
         shutil.copyfileobj(results[0].output, file)
+
 
 @matrix_action
 def report(config, results):
@@ -116,21 +119,26 @@ def report(config, results):
     if 'GITHUB_WORKFLOW' in environ:
         print(f"::set-output name=badge::Unittest-{passed}%20of%20{executed}%20passed-{UNITTEST_BADGE_COLOR[passed == executed]}")
 
+
 @matrix_command(needs_shell=False)
 def run_cbuild(config):
     return ["bash", "-c", f"cbuild.sh --quiet basic.{config.target}.cprj"]
 
+
 @matrix_command(test_report=ConsoleReport()|CropReport("---\[ UNITY BEGIN \]---", '---\[ UNITY END \]---')|UnityReport())
 def run_vht(config):
     return ["VHT_Corstone_SSE-300_Ethos-U55", "-q", "--stat", "--simlimit", "1", "-f", "vht_config.txt", "Objects/basic.axf"]
+
 
 @matrix_command(needs_shell=True, test_report=ConsoleReport()|CropReport("---\[ UNITY BEGIN \]---", '---\[ UNITY END \]---')|UnityReport())
 def cat_log(log):
     cwd = Path.cwd().as_posix().replace('/','\\/')
     return ["bash", "-c", f"\"cat {log} | sed 's/\\/home\\/ubuntu\\/vhtwork/{cwd}/'\""]
 
+
 def timestamp(t: datetime = datetime.now()):
     return t.strftime("%Y%m%d%H%M%S")
+
 
 if __name__ == "__main__":
     main()

--- a/basic/vht.yml
+++ b/basic/vht.yml
@@ -1,21 +1,22 @@
-suite:
-  name: "VHT basic example"
-  model: "VHT_Corstone_SSE-300_Ethos-U55"
-  configuration: ""
-  working_dir: "/home/ubuntu/vhtwork"
-  pre: ""
-  post: ""
-
-  builds:
-   - "basic example":
-      shell: "cbuild.sh ./basic.debug.cprj"
-      pre:
-      post: "cp ./Objects/basic.axf out/"
-
-  tests:
-   - "basic example":
-      executable: "./Objects/basic.axf"
-      arguments: "-f ./vht_config.txt --stat --simlimit 24"
-      pre: ""
-      post: ""
-      timeout: 20
+name: "VHT GetStarted Example"
+workdir: ./
+upload:
+  - RTE/**/*
+  - -:RTE/**/RTE_Components.h
+  - basic.debug.cprj
+  - build.py
+  - main.c
+  - requirements.txt
+  - retarget_stdio.c
+  - vht_config.txt
+  - README.md
+steps:
+  - run: |
+      pip install -r requirements.txt
+      python build.py --verbose cbuild vht
+download:
+  - RTE/**/RTE_Components.h
+  - Objects/basic.axf
+  - Objects/basic.axf.map
+  - basic-*.xunit
+  - vht-*.log


### PR DESCRIPTION
The Python AVH CLI is used to execute the build and test steps on AWS backend.
The very same CLI command can be used on the local machine if the required (secret) environment variables are exported, properly. Using the AVH CLI local backend the full build/test can even be run offline (with similar command line), given the required tools are installed in the local environment.